### PR TITLE
Translation and resolution customization

### DIFF
--- a/src/HostingExtension.cs
+++ b/src/HostingExtension.cs
@@ -1,28 +1,32 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
 
 namespace Unity.Microsoft.DependencyInjection
 {
     public static class HostingExtension
     {
-        private static ServiceProviderFactory _factory;
-
         public static IWebHostBuilder UseUnityServiceProvider(this IWebHostBuilder hostBuilder, IUnityContainer container = null)
         {
-            _factory = new ServiceProviderFactory(container);
+            return UseUnityServiceProvider(hostBuilder, c => c.UnityContainer = container);
+        }
+
+        public static IWebHostBuilder UseUnityServiceProvider(this IWebHostBuilder hostBuilder, Action<UnityConfigurationOptions> config)
+        {
+            var factory = new ServiceProviderFactory(config);
 
 #if NETCOREAPP1_1
             return hostBuilder.ConfigureServices((services) =>
             {
-                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IUnityContainer>>(_factory));
-                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IServiceCollection>>(_factory));
+                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IUnityContainer>>(factory));
+                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IServiceCollection>>(factory));
             });
 #else
             return hostBuilder.ConfigureServices((context, services) =>
             {
-                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IUnityContainer>>(_factory));
-                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IServiceCollection>>(_factory));
+                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IUnityContainer>>(factory));
+                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IServiceCollection>>(factory));
             });
 #endif
         }

--- a/src/Policy/ConstructorSelectorPolicy.cs
+++ b/src/Policy/ConstructorSelectorPolicy.cs
@@ -48,8 +48,7 @@ namespace Unity.Microsoft.DependencyInjection.Policy
                 case 1: return injectionConstructors[0];
                 default:
                     throw new InvalidOperationException(
-               $"Existem multiplos construtores decorados com Inject para a classe " +
-               $"{context.BuildKey.Type.GetTypeInfo().Name}");
+               $"There are multiple constructors decorated with Inject attribute for the class {context.BuildKey.Type.GetTypeInfo().Name}");
             }
         }
 
@@ -115,8 +114,7 @@ namespace Unity.Microsoft.DependencyInjection.Policy
                                 && !parameters.All(p => p.ParameterType.GetTypeInfo().IsInterface))
                                 return bestConstructor;
 
-                            var msg = $"Falha ao procurar um construtor para {context.BuildKey.Type.FullName}\n" +
-                                $"Há uma abiquidade entre os construtores";
+                            var msg = $"Failed to search for a constructor for {context.BuildKey.Type.FullName}{Environment.NewLine}There is an abnormality between the constructors";
                             throw new InvalidOperationException(msg);
                         }
                         else
@@ -131,7 +129,7 @@ namespace Unity.Microsoft.DependencyInjection.Policy
             {
                 //return null;
                 throw new InvalidOperationException(
-                    $"Construtor não encontrado para {context.BuildKey.Type.FullName}");
+                    $"Constructor not found for {context.BuildKey.Type.FullName}");
             }
             else
             {

--- a/src/ServiceProviderExtensions.cs
+++ b/src/ServiceProviderExtensions.cs
@@ -17,8 +17,10 @@ namespace Unity.Microsoft.DependencyInjection
         /// <returns>The <see cref="ServiceProvider"/>.</returns>
         public static IServiceProvider BuildServiceProvider(this IServiceCollection services, bool validateScopes = false)
         {
-            return new ServiceProvider(new UnityContainer().AddExtension(new MdiExtension())
-                                                           .AddServices(services));
+            var container = new UnityContainer().AddExtension(new MdiExtension())
+                                               .AddServices(services);
+
+            return new ServiceProvider(new UnityConfigurationOptions { UnityContainer = container });
         }
 
         /// <summary>
@@ -30,8 +32,10 @@ namespace Unity.Microsoft.DependencyInjection
         /// <returns>Service provider</returns>
         public static IServiceProvider BuildServiceProvider(this IServiceCollection services, IUnityContainer container)
         {
-            return new ServiceProvider(container.AddExtension(new MdiExtension())
-                                                .AddServices(services));
+            container.AddExtension(new MdiExtension())
+                     .AddServices(services);
+
+            return new ServiceProvider(new UnityConfigurationOptions { UnityContainer = container });
         }
 
         /// <summary>
@@ -43,8 +47,10 @@ namespace Unity.Microsoft.DependencyInjection
         /// <returns>Service provider</returns>
         public static IServiceProvider BuildServiceProvider(this IUnityContainer container, IServiceCollection services)
         {
-            return new ServiceProvider(container.AddExtension(new MdiExtension())
-                                                .AddServices(services));
+            container.AddExtension(new MdiExtension())
+                     .AddServices(services);
+
+            return new ServiceProvider(new UnityConfigurationOptions { UnityContainer = container });
         }
     }
 }

--- a/src/Unity.Microsoft.DependencyInjection.csproj
+++ b/src/Unity.Microsoft.DependencyInjection.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\package.props" />
 
   <PropertyGroup>
-    <FileVersion>$(Version).0</FileVersion>
-    <AssemblyVersion>$(Version).0</AssemblyVersion>
+    <FileVersion>2.1.2.1</FileVersion>
+    <AssemblyVersion>2.1.2.1</AssemblyVersion>
     <PackageId>Unity.Microsoft.DependencyInjection</PackageId>
     <Description>Unity for Microsoft Dependency Injection framework.</Description>
     <Copyright>Copyright © Unity Container Project 2018</Copyright>
@@ -19,11 +19,13 @@
     <RootNamespace>Unity.Microsoft.DependencyInjection</RootNamespace>
     <UnityAbstractions>..\..\Abstractions\src\Unity.Abstractions.csproj</UnityAbstractions>
     <UnityContainer>..\..\Container\src\Unity.Container.csproj</UnityContainer>
+    <Version>2.1.2.1</Version>
+    <PackageReleaseNotes>Extended to allow for resolution customization. Updated error language to english.</PackageReleaseNotes>
   </PropertyGroup>
 
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/UnityConfigurationOptions.cs
+++ b/src/UnityConfigurationOptions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Unity.Resolution;
+
+namespace Unity.Microsoft.DependencyInjection
+{
+    public class UnityConfigurationOptions
+    {
+        /// <summary>
+        /// The container to use as the root container.
+        /// </summary>
+        public IUnityContainer UnityContainer { get; set; }
+        /// <summary>
+        /// Controls the unity resolution parameters when resolving a type via the ServiceProvider.
+        /// </summary>
+        public Action<ResolutionParameters> ResolveConfiguration { get; set; }
+        /// <summary>
+        /// Configures the scope options when a new child scope is created.
+        /// </summary>
+        public Action<UnityConfigurationOptions> CreateScope { get; set; }
+
+        public UnityConfigurationOptions With(IUnityContainer unityContainer = null, Action<ResolutionParameters> resolutionConfiguration = null, Action<UnityConfigurationOptions> createScope = null)
+        {
+            return new UnityConfigurationOptions
+            {
+                UnityContainer = unityContainer ?? UnityContainer,
+                ResolveConfiguration = resolutionConfiguration ?? ResolveConfiguration,
+                CreateScope = createScope ?? CreateScope
+            };
+        }
+    }
+
+    public class ResolutionParameters
+    {
+        /// <summary>
+        /// The type being resolved.
+        /// </summary>
+        public Type Type { get; set; }
+        /// <summary>
+        /// The name to use when resolving the type.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// The resolver overrides to use when resolving the type.
+        /// </summary>
+        public ResolverOverride[] ResolverOverrides { get; set; }
+        /// <summary>
+        /// Action to call when a type resolution fails.
+        /// </summary>
+        public Action<Type> ResolutionFailureHanlder { get; set; }
+    }
+}


### PR DESCRIPTION
Translated error messages to english per issue 19.

Added resolution customization.

**Justification:** 
Currently, there is no way to hook into the resolution of a type. Unity provide ResolutionOverrides and named registrations, which we can't use since the Micrososft ServiceProvider only passing in a type. This pull request adds a non breaking change that allows the user to specify the following options:

ResolveConfiguration - An action that will be called (if set) per resolution that allows the client to customize the parameters passed into unity.

CreateScope - An action that will be called (if set) when a child container is created by the ServiceProvider.

**Use case:** When there is a request to the service with the header "dryrun", the service should run the validation, but not apply the changes to the database.

**Implementation:** Upon creating the child scope, check for the existiance of the header. If the header exists, create a ResolverOverride for your UnitOfWork that doesn't save changes. Use ResolveConfiguration to pass that ResolverOverride to Unity.