### PR TITLE
V5.11.1

### DIFF
--- a/package.sln
+++ b/package.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29409.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unity.DependencyInjection", "src\Unity.Microsoft.DependencyInjection.csproj", "{520251C7-14E6-434F-A26E-67E9762635BD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unity.Microsoft.DependencyInjection", "src\Unity.Microsoft.DependencyInjection.csproj", "{520251C7-14E6-434F-A26E-67E9762635BD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{DA61FEC3-1E17-4DCF-AC19-A6482A547741}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyInjection.Tests", "tests\Unity.Microsoft.DependencyInjection.Tests.csproj", "{FCC3DAA4-9136-4C55-926D-7DBD5BEDE8D8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unity.Microsoft.DependencyInjection.Tests", "tests\Unity.Microsoft.DependencyInjection.Tests.csproj", "{FCC3DAA4-9136-4C55-926D-7DBD5BEDE8D8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Unity.Microsoft.DependencyInjection.csproj
+++ b/src/Unity.Microsoft.DependencyInjection.csproj
@@ -65,7 +65,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Version>5.11.1-beta</Version>
+    <Version>5.11.1-beta2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Unity.Microsoft.DependencyInjection.csproj
+++ b/src/Unity.Microsoft.DependencyInjection.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" /> 
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0-preview1.19506.1" /> 
   </ItemGroup>
 
   <!-- Sourcelink -->

--- a/src/Unity.Microsoft.DependencyInjection.csproj
+++ b/src/Unity.Microsoft.DependencyInjection.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\package.props" />
 
   <PropertyGroup>
-    <FileVersion>$(Version).0</FileVersion>
-    <AssemblyVersion>$(Version).0</AssemblyVersion>
+    <FileVersion>5.11.1.0</FileVersion>
+    <AssemblyVersion>5.11.1.0</AssemblyVersion>
     <PackageId>Unity.Microsoft.DependencyInjection</PackageId>
     <Description>Unity for Microsoft Dependency Injection framework.</Description>
     <Copyright>Copyright © Unity Container Project 2018</Copyright>
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="!Exists('$(UnityContainer)')">
-    <PackageReference Include="Unity.Container" Version="$(UnityContainerVersion)" />
+    <PackageReference Include="Unity.Container" Version="5.11.1" />
   </ItemGroup>
 
 
@@ -57,7 +57,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" /> 
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" /> 
   </ItemGroup>
 
   <!-- Sourcelink -->
@@ -65,6 +65,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Version>5.11.1-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Unity.Microsoft.DependencyInjection.Tests.csproj
+++ b/tests/Unity.Microsoft.DependencyInjection.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="3.1.0-preview1.19506.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Unity.Microsoft.DependencyInjection.Tests.csproj
+++ b/tests/Unity.Microsoft.DependencyInjection.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi,

This PR gets 5.11.1 working, however please note the following:

- I manually modified package versions (to publish on a private nuget server) you may need to revise this to bring back build variables.
- The test below is failing, but I don't consider it a blocker myself, I guess Unity handle mixed generics differently from MS DI.

```
Unity.Microsoft.DependencyInjection.Tests.Tests.ResolvesMixedOpenClosedGenericsAsEnumerable
  No source available
   Duration: 5 ms

  Message: 
    Assert.Equal() Failure
    Expected: 3
    Actual:   2
  Stack Trace: 
    DependencyInjectionSpecificationTests.ResolvesMixedOpenClosedGenericsAsEnumerable()
```

Cheers,
P.