### PR TITLE
Fixed issue where incorrect provider passed to factory delegate

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -50,9 +50,7 @@ namespace Unity.Microsoft.DependencyInjection
                                        qualifier,
                                         scope =>
                                         {
-                                            var serviceProvider = serviceDescriptor.Lifetime == ServiceLifetime.Scoped
-                                                ? scope.Resolve<IServiceProvider>()
-                                                : container.Resolve<IServiceProvider>();
+                                            var serviceProvider = scope.Resolve<IServiceProvider>();
                                             var instance = serviceDescriptor.ImplementationFactory(serviceProvider);
                                             return instance;
                                         },

--- a/tests/ScopedDepencencyTests.cs
+++ b/tests/ScopedDepencencyTests.cs
@@ -17,8 +17,6 @@ namespace Unity.Microsoft.DependencyInjection.Tests
             var provider = collection.BuildServiceProvider();
 
             // Act
-            //var rootTransient = provider.GetService<Transient>();
-            
             ITransient transient1 = null;
             ITransient transient2a = null;
             ITransient transient2b = null;

--- a/tests/ScopedDepencencyTests.cs
+++ b/tests/ScopedDepencencyTests.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Unity.Microsoft.DependencyInjection.Tests
+{
+    public class ScopedDepencencyTests
+    {
+        [Fact]
+        public void ScopedDependencyFromTransientFactoryNotSharedAcrossScopes()
+        {
+            // Arrange
+            var collection = new TestServiceCollection()
+                                .AddTransient<ITransient>(CreateTransient)
+                                .AddScoped<IScoped, Scoped>();
+
+            var provider = collection.BuildServiceProvider();
+
+            // Act
+            //var rootTransient = provider.GetService<Transient>();
+            
+            ITransient transient1 = null;
+            ITransient transient2a = null;
+            ITransient transient2b = null;
+
+            using (var scope1 = provider.CreateScope())
+            {
+                transient1 = scope1.ServiceProvider.GetService<ITransient>();
+            }
+
+            using (var scope2 = provider.CreateScope())
+            {
+                transient2a = scope2.ServiceProvider.GetService<ITransient>();
+                transient2b = scope2.ServiceProvider.GetService<ITransient>();
+            }
+
+            // Assert
+            Assert.NotSame(transient1, transient2a);
+            Assert.NotSame(transient2a, transient2b);
+            Assert.NotSame(transient1.ScopedDependency, transient2a.ScopedDependency);
+            Assert.Same(transient2a.ScopedDependency, transient2b.ScopedDependency);
+        }
+
+        private ITransient CreateTransient(System.IServiceProvider provider)
+        {
+            return provider.GetRequiredService<Transient>();
+        }
+
+        public interface ITransient {
+            IScoped ScopedDependency { get; }
+        }
+
+        public class Transient : ITransient
+        {
+            public Transient(IScoped scoped)
+            {
+                ScopedDependency = scoped;
+            }
+
+            public IScoped ScopedDependency { get; }
+        }
+
+        public interface IScoped { }
+
+        public class Scoped : IScoped
+        {
+        }
+
+    }
+
+    internal class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
+    {
+    }
+}


### PR DESCRIPTION
When registering a factory delegate for a transient type, the service provider passed to the delegate is the root container. Therefore, if that transient type has a scoped dependency, that dependency is resolved from the root container across scopes. 

I've updated to always resolve from the scoped provider.

I've added a unit test to show the bug. Not sure if something like this has been added to the `Microsoft.Extensions.DependencyInjection.Specification.Tests` since 2.2.0, but I've added it in it's own test class. 