### PR TITLE
Scoped provider now used for factory methods

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -50,9 +50,7 @@ namespace Unity.Microsoft.DependencyInjection
                                        qualifier,
                                         scope =>
                                         {
-                                            var serviceProvider = serviceDescriptor.Lifetime == ServiceLifetime.Scoped
-                                                ? scope.Resolve<IServiceProvider>()
-                                                : container.Resolve<IServiceProvider>();
+                                            var serviceProvider = scope.Resolve<IServiceProvider>();
                                             var instance = serviceDescriptor.ImplementationFactory(serviceProvider);
                                             return instance;
                                         },

--- a/tests/ScopedDepencencyTests.cs
+++ b/tests/ScopedDepencencyTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Unity.Microsoft.DependencyInjection.Tests
+{
+    public class ScopedDepencencyTests
+    {
+        [Fact]
+        public void ScopedDependencyFromTransientFactoryNotSharedAcrossScopes()
+        {
+            // Arrange
+            var collection = new TestServiceCollection()
+                                .AddTransient<ITransient>(CreateTransientFactory)
+                                .AddScoped<IScoped, Scoped>();
+
+            var provider = collection.BuildServiceProvider();
+
+            // Act
+            ITransient transient1 = null;
+            ITransient transient2a = null;
+            ITransient transient2b = null;
+
+            using (var scope1 = provider.CreateScope())
+            {
+                transient1 = scope1.ServiceProvider.GetService<ITransient>();
+            }
+
+            using (var scope2 = provider.CreateScope())
+            {
+                transient2a = scope2.ServiceProvider.GetService<ITransient>();
+                transient2b = scope2.ServiceProvider.GetService<ITransient>();
+            }
+
+            // Assert
+            Assert.NotSame(transient1, transient2a);
+            Assert.NotSame(transient2a, transient2b);
+            Assert.NotSame(transient1.ScopedDependency, transient2a.ScopedDependency);
+            Assert.Same(transient2a.ScopedDependency, transient2b.ScopedDependency);
+        }
+
+        private ITransient CreateTransientFactory(System.IServiceProvider provider)
+        {
+            return provider.GetRequiredService<Transient>();
+        }
+
+        public interface ITransient {
+            IScoped ScopedDependency { get; }
+        }
+
+        public class Transient : ITransient
+        {
+            public Transient(IScoped scoped)
+            {
+                ScopedDependency = scoped;
+            }
+
+            public IScoped ScopedDependency { get; }
+        }
+
+        public interface IScoped { }
+
+        public class Scoped : IScoped
+        {
+        }
+
+    }
+
+    internal class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
+    {
+    }
+}


### PR DESCRIPTION
New PR based off `release/5.11` as requested in #63 

Added ScopedDependencyFromTransientFactoryNotSharedAcrossScopes test which fails when checking that different instances of scoped are checked to be different in different scopes.

When calling the factory method, the scoped provider is now always passed to the delegate. Previously, the root container was being passed for transients, so if a transient had a scoped dependency it would be resolved from the root too and would be used across scopes.