### PR TITLE
Make InjectionTransientLifetimeManager public

### DIFF
--- a/src/Lifetime/InjectionTransientLifetimeManager.cs
+++ b/src/Lifetime/InjectionTransientLifetimeManager.cs
@@ -8,7 +8,7 @@ namespace Unity.Microsoft.DependencyInjection.Lifetime
     /// except it makes container remember all Disposable objects it created. Once container
     /// is disposed all these objects are disposed as well.
     /// </summary>
-    internal class InjectionTransientLifetimeManager : LifetimeManager, 
+    public class InjectionTransientLifetimeManager : LifetimeManager, 
                                                        IFactoryLifetimeManager,
                                                        ITypeLifetimeManager
     {


### PR DESCRIPTION
`InjectionTransientLifetimeManager` is the only LifeTimeManger which class is made internal.
By making it public, people like us who use your library to extend upon can also make use of it.