### PR TITLE
Make Configuration.AddServices public

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -7,11 +7,20 @@ using Unity.Microsoft.DependencyInjection.Lifetime;
 
 namespace Unity.Microsoft.DependencyInjection
 {
-    internal static class Configuration
+    public static class Configuration
     {
-        internal static IUnityContainer AddServices(this IUnityContainer container, IServiceCollection services)
+        public static IUnityContainer AddServices(this IUnityContainer container, IServiceCollection services)
         {
-            var lifetime = ((UnityContainer)container).Configure<MdiExtension>().Lifetime;
+            var extension = ((UnityContainer)container).Configure<MdiExtension>();
+
+            if (extension == null)
+            {
+                extension = new MdiExtension();
+                container.AddExtension(extension);
+            }
+
+            var lifetime = extension.Lifetime;
+            
             var registerFunc = ((UnityContainer)container).Register;
 
             ((UnityContainer)container).Register = ((UnityContainer)container).AppendNew;


### PR DESCRIPTION
Modified access modifier to `public` so that library users can use `AddServices` method.

In addition, since the access modifier of `MdiExtension` is` internal`, it is modified to add if `MdiExtension` does not exist in the container within the `AddServices` method.