### PR TITLE
Updated package to use Keyed Services

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ after_build:
 - choco install codecov
 
 test_script:
-- OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test --framework netcoreapp2.0 --verbosity q"
+- OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test --framework net8.0 --verbosity q"
 
 after_test:
 - codecov -f "results.xml" 

--- a/src/Unity.Microsoft.DependencyInjection.csproj
+++ b/src/Unity.Microsoft.DependencyInjection.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;netstandard2.0</TargetFrameworks>
     <DebugType>Portable</DebugType>
   </PropertyGroup>
 

--- a/src/Unity.Microsoft.DependencyInjection.csproj
+++ b/src/Unity.Microsoft.DependencyInjection.csproj
@@ -46,12 +46,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="!Exists('$(UnityContainer)')">
-    <PackageReference Include="Unity.Container" Version="$(UnityContainerVersion)" />
+    <PackageReference Include="Unity.Container" Version="5.11.11" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" /> 
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" /> 
   </ItemGroup>
 
   <!-- Sourcelink -->
@@ -62,7 +62,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Unity.Microsoft.DependencyInjection.Tests.csproj
+++ b/tests/Unity.Microsoft.DependencyInjection.Tests.csproj
@@ -1,22 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <RootNamespace>Unity.Microsoft.DependencyInjection.Tests</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<RootNamespace>Unity.Microsoft.DependencyInjection.Tests</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="xunit" Version="2.7.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\src\Unity.Microsoft.DependencyInjection.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\src\Unity.Microsoft.DependencyInjection.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/tests/UnityDependencyInjectionTests.cs
+++ b/tests/UnityDependencyInjectionTests.cs
@@ -10,6 +10,9 @@ namespace Unity.Microsoft.DependencyInjection.Specification.Tests
 {
     public class Tests : DependencyInjectionSpecificationTests
     {
+        public override bool SupportsIServiceProviderIsService => false;
+        public override bool ExpectStructWithPublicDefaultConstructorInvoked => true;
+
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
         {
             return serviceCollection.BuildServiceProvider();


### PR DESCRIPTION
When trying to migrate a project to dotnet core, I noticed that even though Keyed/Named services were apart of Unity the Service Provider builder, did not support it.

* I've updated the dependencies for the Service Provider and Tests to dotnet8
* Added the required interface to allow for the Keyed Services
* Updated the Configuration to allow for registering the ServiceCollection into the IUnityContainer